### PR TITLE
Add definitions for documented TABLE_SORT_CATEG_MIN/MAX flags

### DIFF
--- a/include/MAPIDefS.h
+++ b/include/MAPIDefS.h
@@ -1135,6 +1135,9 @@ DECLARE_MAPI_INTERFACE_(IMAPIProp, IUnknown)
 #define TABLE_SORT_DESCEND		((ULONG) 0x00000001)
 #define TABLE_SORT_COMBINE		((ULONG) 0x00000002)
 
+// Documented here: https://learn.microsoft.com/en-us/office/client-developer/outlook/mapi/ssortorder
+#define TABLE_SORT_CATEG_MAX	((ULONG) 0x00000004)
+#define TABLE_SORT_CATEG_MIN	((ULONG) 0x00000008)
 
 /* Data structures */
 


### PR DESCRIPTION
The documentation even includes a note about this:

> The ulOrder member values TABLE_SORT_CATEG_MAX and TABLE_SORT_CATEG_MIN might not be defined in the downloadable header file you currently have, in which case you can add it to your code using the following values: #define TABLE_SORT_CATEG_MAX ((ULONG) 0x00000004)> #define TABLE_SORT_CATEG_MIN ((ULONG) 0x00000008)

We should just go ahead and define them, so this is no longer necessary. This could trigger a build break for consumers, if they didn't wrap the macro `#define` directives in `#ifndef`, but it's unlikely that there are many users of these flags, and it should be pretty obvious how to fix it if they pull a new version of this header from this project and get an error that the macros are already defined.

I'll also make a pull request to the documentation page to suggest wrapping those `#define` directives in `#ifndef` in that note.