### PR TITLE
Update documentation link to point to redirected page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MAPIStubLibrary
 The MAPI Stub Library is a drop in replacement for mapi32.lib which supports building both 32 and 64 bit MAPI applications. This library eliminates the need to explicitly link to MAPI.
 
-**See the [documentation](https://msdn.microsoft.com/en-us/library/office/cc963763.aspx) for information on building the MAPI Stub Library and integrating it into your project.**
+**See the [documentation](https://learn.microsoft.com/en-us/office/client-developer/outlook/mapi/how-to-link-to-mapi-functions) for information on building the MAPI Stub Library and integrating it into your project.**\
 **See the [FAQ](https://mapistublibrary.codeplex.com/wikipage?title=FAQ) for questions about this library, such as when and why to use it.**


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/office/cc963763.aspx redirects to https://learn.microsoft.com/en-us/office/client-developer/outlook/mapi/how-to-link-to-mapi-functions

I also properly split the two lines into their own lines when rendered in Markdown