### PR TITLE
U/sgriffin/docs

### DIFF
--- a/docs/Building.md
+++ b/docs/Building.md
@@ -61,6 +61,7 @@ Alternatively, you can build using Node.js and node-gyp (this creates a static l
    npm run build:x64    # 64-bit library
    npm run build:x86    # 32-bit library  
    npm run build:arm64  # ARM64 library
+   npm run build:all    # Build all architectures
    ```
 
    **Clean build artifacts:**
@@ -69,7 +70,11 @@ Alternatively, you can build using Node.js and node-gyp (this creates a static l
    npm run clean
    ```
 
-The output will be `MAPIStubLibrary.lib` in the `build/Release` directory.
+The outputs will be in architecture-specific directories:
+
+- `build/lib/x64/MAPIStubLibrary.lib` - 64-bit library
+- `build/lib/ia32/MAPIStubLibrary.lib` - 32-bit library  
+- `build/lib/arm64/MAPIStubLibrary.lib` - ARM64 library
 
 ## Build Output
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "MAPI Stub Library for 32 and 64 bit applications",
   "scripts": {
     "build": "node-gyp rebuild",
-    "build:x64": "node-gyp rebuild --arch=x64",
-    "build:x86": "node-gyp rebuild --arch=ia32",
-    "build:arm64": "node-gyp rebuild --arch=arm64",
+    "build:x64": "node-gyp configure --arch=x64 && node-gyp build --arch=x64",
+    "build:x86": "node-gyp configure --arch=ia32 && node-gyp build --arch=ia32",
+    "build:arm64": "node-gyp configure --arch=arm64 && node-gyp build --arch=arm64",
+    "build:all": "npm run build:x64 && npm run build:x86 && npm run build:arm64",
     "clean": "node-gyp clean",
     "clean:all": "node-gyp clean && rmdir /s /q build 2>nul || true"
   },


### PR DESCRIPTION
This pull request improves the build process for the MAPI Stub Library by adding support for building all target architectures at once, updating build scripts for reliability, and clarifying the build output directory structure in the documentation.

Build process improvements:

* Added a new `build:all` script to `package.json` that builds the library for x64, x86, and arm64 architectures in one command.
* Updated individual architecture build scripts (`build:x64`, `build:x86`, `build:arm64`) to run `node-gyp configure` before `node-gyp build` for more reliable builds.

Documentation updates:

* Updated `docs/Building.md` to include instructions for the new `build:all` command.
* Clarified the output directory structure in `docs/Building.md`, specifying that built libraries are placed in architecture-specific directories.